### PR TITLE
add four interrupt sources for ATSAMD5x

### DIFF
--- a/templates/driver/usbfsv1/system_init_c_driver_data.ftl
+++ b/templates/driver/usbfsv1/system_init_c_driver_data.ftl
@@ -89,7 +89,7 @@ void _DRV_USB_VBUSPowerEnable(uint8_t port, bool enable)
 
 const DRV_USBFSV1_INIT drvUSBInit =
 {
-	<#if __PROCESSOR?matches("ATSAME5.*") == true>
+	<#if __PROCESSOR?matches("ATSAM[D,E]5.*") == true>
 	/* Interrupt Source for USB module */
 	.interruptSource = USB_OTHER_IRQn,
  


### PR DESCRIPTION
ATSAMD5x needs four interrupt sources configured, otherwise the build fails